### PR TITLE
Fix username labels. Allow mismatched usernames.

### DIFF
--- a/main.py
+++ b/main.py
@@ -434,6 +434,7 @@ while not monitor.abortRequested():
         trakt_users.append(c_trakt_user)
         trakt_list_start+=1
         trakt_tag_start+=1
+        trakt_user_start+=1
         c_trakt_list = __settings__.getSetting(str(trakt_list_start))
         c_trakt_tag = __settings__.getSetting(str(trakt_tag_start))
         c_trakt_user = __settings__.getSetting(str(trakt_user_start))

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -33,19 +33,19 @@
         <setting label="30917" id="32032" type="action" visible="eq(-1,true)" action="RunScript(script.tag-generator, trakt_init)"/>
         <setting label="30918" type="text" id="32031" enable="fdalse" visible="eq(-2,true)" default="-please request token-"/>
         <setting label="30921" id="32098" visible="eq(-3,true)" default="1" type="enum" values="1|2|3|4|5"/>
-        <setting label="30929" type="text" id="32160" visible="eq(-4,true)" default="TraktUser1"/>
+        <setting label="30929" type="text" visible="eq(-4,true)" id="32160" default="TraktUser1"/>
         <setting label="30922" type="text" visible="eq(-5,true)" id="32120" default="UserList1"/>
         <setting label="30903" type="text" visible="eq(-6,true)" id="32140" default="UserTag1"/>
-        <setting label="30922" type="text" visible="gt(-4,0) + eq(-7,true)" id="32161" default="TraktUser2"/>
+        <setting label="30929" type="text" visible="gt(-4,0) + eq(-7,true)" id="32161" default="TraktUser2"/>
         <setting label="30922" type="text" visible="gt(-5,0) + eq(-8,true)" id="32121" default="UserList2"/>
         <setting label="30903" type="text" visible="gt(-6,0) + eq(-9,true)" id="32141" default="UserTag2"/>
-        <setting label="30922" type="text" visible="gt(-7,1) + eq(-10,true)" id="32162" default="TraktUser3"/>
+        <setting label="30929" type="text" visible="gt(-7,1) + eq(-10,true)" id="32162" default="TraktUser3"/>
         <setting label="30922" type="text" visible="gt(-8,1) + eq(-11,true)" id="32122" default="UserList3"/>
         <setting label="30903" type="text" visible="gt(-9,1) + eq(-12,true)" id="32142" default="UserTag3"/>
-        <setting label="30922" type="text" visible="gt(-10,2) + eq(-13,true)" id="32163" default="TraktUser4"/>
+        <setting label="30929" type="text" visible="gt(-10,2) + eq(-13,true)" id="32163" default="TraktUser4"/>
         <setting label="30922" type="text" visible="gt(-11,2) + eq(-14,true)" id="32123" default="UserList4"/>
         <setting label="30903" type="text" visible="gt(-12,2) + eq(-15,true)" id="32143" default="UserTag4"/>
-        <setting label="30922" type="text" visible="gt(-13,3) + eq(-16,true)" id="32164" default="TraktUser5"/>
+        <setting label="30929" type="text" visible="gt(-13,3) + eq(-16,true)" id="32164" default="TraktUser5"/>
         <setting label="30922" type="text" visible="gt(-14,3) + eq(-17,true)" id="32124" default="UserList5"/>
         <setting label="30903" type="text" visible="gt(-15,3) + eq(-18,true)" id="32144" default="UserTag5"/>
     </category>


### PR DESCRIPTION
Currently, when you select more than 1 list, it shows "Trakt List Name" in place of the "Trakt Username" field for lists 2-5. Specifying different usernames is also ignored and only the first username is used. This fixes both issues.